### PR TITLE
add flags for jx import remote cluster

### DIFF
--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -114,6 +114,9 @@ type ImportOptions struct {
 	Destination           ImportDestination
 	reporter              ImportReporter
 	PackFilter            func(*Pack)
+	// env customization
+	EnvName               string
+	EnvStrategy           string
 
 	/*
 		TODO jenkins support
@@ -243,6 +246,10 @@ func (o *ImportOptions) AddImportFlags(cmd *cobra.Command, createProject bool) {
 	cmd.Flags().BoolVarP(&o.IgnoreCollaborator, "no-collaborator", "", false, "disables checking if the bot user is a collaborator. Only used if you have an issue with your git provider and this functionality in go-scm")
 	cmd.Flags().DurationVarP(&o.PullRequestPollPeriod, "pr-poll-period", "", time.Second*20, "the time between polls of the Pull Request on the cluster environment git repository")
 	cmd.Flags().DurationVarP(&o.PullRequestPollTimeout, "pr-poll-timeout", "", time.Minute*20, "the maximum amount of time we wait for the Pull Request on the cluster environment git repository")
+
+	cmd.Flags().StringVar(&o.EnvName, "env-name", "", "The name of the environment to create (only used for env projects)")
+	// FIXME parse enum and through what specified do not fit in enum
+	cmd.Flags().StringVar(&o.EnvStrategy, "env-strategy", "Never", "The promotion strategy of the environment to create (only used for env projects)")
 
 	o.BaseOptions.AddBaseFlags(cmd)
 	o.ScmFactory.AddFlags(cmd)

--- a/pkg/cmd/importcmd/source_config_pr.go
+++ b/pkg/cmd/importcmd/source_config_pr.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jenkins-x-plugins/jx-gitops/pkg/cmd/repository/add"
 	"github.com/jenkins-x-plugins/jx-promote/pkg/environments"
 	"github.com/jenkins-x/go-scm/scm"
+	v1 "github.com/jenkins-x/jx-api/v4/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/kube/jxenv"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/stringhelpers"
 	"github.com/jenkins-x/jx-logging/v3/pkg/log"
@@ -77,7 +78,7 @@ func (o *ImportOptions) addSourceConfigPullRequest(gitURL string, gitKind string
 			return errors.Wrapf(err, "failed to add git URL %s to the source-config.yaml file", safeGitURL)
 		}
 
-		remoteCluster, err = o.modifyDevEnvironmentSource(o.Dir, dir, o.gitInfo, safeGitURL, gitKind)
+		remoteCluster, err = o.modifyDevEnvironmentSource(o.Dir, dir, o.gitInfo, safeGitURL, gitKind, o.EnvName, v1.PromotionStrategyType(o.EnvStrategy))
 		if err != nil {
 			return errors.Wrapf(err, "failed to modify remote cluster")
 		}


### PR DESCRIPTION
Default behavior was changed when importing a remote env from "Auto" to "Never" the idea being:
You don't want other apps to auto promote to that env.
Ability to give a custom name to the env was also added  (all repos have by default the same name, jx3-kubernetes-production, just in different orgs)

Signed-off-by: Youssef El Houti <youssef.elhouti@gmail.com>