### PR TITLE
fix: add_collaborator.go

### DIFF
--- a/pkg/cmd/importcmd/add_collabotor.go
+++ b/pkg/cmd/importcmd/add_collabotor.go
@@ -65,11 +65,11 @@ func (o *ImportOptions) AddAndAcceptCollaborator(newRepository bool) error {
 		// Make the invitation
 		alreadyMember := false
 		_, alreadyMember, _, err = scmClient.Repositories.AddCollaborator(ctx, fullRepoName, pipelineUserName, permission)
-		if err != nil {
-			return errors.Wrapf(err, "failed to add %s as a collaborator to %s", pipelineUserName, fullRepoName)
-		}
 		if alreadyMember {
 			return nil
+		}
+		if err != nil {
+			return errors.Wrapf(err, "failed to add %s as a collaborator to %s", pipelineUserName, fullRepoName)
 		}
 
 		if o.OperatorNamespace == "" {

--- a/pkg/cmd/importcmd/add_collabotor.go
+++ b/pkg/cmd/importcmd/add_collabotor.go
@@ -63,7 +63,22 @@ func (o *ImportOptions) AddAndAcceptCollaborator(newRepository bool) error {
 	// If the user creating the repo is not the pipeline user, add the pipeline user as a contributor to the repo
 	if pipelineUserName != "" && pipelineUserName != userName { // TODO: not sure why:  && o.ScmFactory.GitServerURL == o.PipelineServer {
 		// Make the invitation
-		_, _, _, err = scmClient.Repositories.AddCollaborator(ctx, fullRepoName, pipelineUserName, permission)
+		switch o.ScmFactory.GitKind {
+		case "github":
+			_, _, _, err = scmClient.Repositories.AddCollaborator(ctx, fullRepoName, pipelineUserName, permission)
+		case "gitlab":
+			repoPath := scm.Join(owner, repoName)
+			repo, _, err := scmClient.Repositories.Find(ctx, repoPath)
+			if err != nil {
+				return errors.Wrapf(err, "failed to resolve gitlab repo id for %s", repoName)
+			}
+			_, _, _, err = scmClient.Repositories.AddCollaborator(ctx, repo.ID, pipelineUserName, permission)
+			if err != nil {
+				return errors.Wrapf(err, "failed to add %s as a collaborator to %s", pipelineUserName, repoName)
+			}
+			// that's it for GitLab, no invitations to accept
+			return nil
+		}
 		if err != nil {
 			return errors.Wrapf(err, "failed to add %s as a collaborator to %s", pipelineUserName, fullRepoName)
 		}


### PR DESCRIPTION
- gitlab doesn't use invitations, but directly adds members to repos
- the api call requires the project id, which has to be looked up first

Signed-off-by: Manuel Stein <manuel.stein@nokia-bell-labs.com>