### PR TITLE
refactor: use T.TempDir to create temporary test directory

### DIFF
--- a/pkg/cmd/importcmd/import_bad_name_integration_test.go
+++ b/pkg/cmd/importcmd/import_bad_name_integration_test.go
@@ -3,7 +3,6 @@
 package importcmd_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -21,11 +20,10 @@ import (
 )
 
 func TestImportBadNameProject(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "test-import-jx-gha-")
-	assert.NoError(t, err)
+	tempDir := t.TempDir()
 
 	testData := path.Join("test_data", "import_projects")
-	_, err = os.Stat(testData)
+	_, err := os.Stat(testData)
 	assert.NoError(t, err)
 
 	name := "docker_slave_18.04"

--- a/pkg/cmd/importcmd/import_deploy_integration_test.go
+++ b/pkg/cmd/importcmd/import_deploy_integration_test.go
@@ -27,8 +27,7 @@ func TestImportProjectNextGenPipelineWithDeploy(t *testing.T) {
 	t.SkipNow()
 
 	t.Parallel()
-	tmpDir, err := ioutil.TempDir("", "test-import-deploy-projects-")
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 	require.DirExists(t, tmpDir, "could not create temp dir for running tests")
 
 	srcDir := path.Join("test_data", "import_projects", "nodejs")
@@ -98,7 +97,7 @@ func TestImportProjectNextGenPipelineWithDeploy(t *testing.T) {
 		}
 		dir := filepath.Join(tmpDir, name)
 
-		err = files.CopyDir(srcDir, dir, true)
+		err := files.CopyDir(srcDir, dir, true)
 		require.NoError(t, err, "failed to copy source to %s", dir)
 
 		_, io := importcmd.NewCmdImportAndOptions()

--- a/pkg/cmd/importcmd/import_github_action_integration_test.go
+++ b/pkg/cmd/importcmd/import_github_action_integration_test.go
@@ -3,7 +3,6 @@
 package importcmd_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -25,11 +24,10 @@ func TestImportGitHubActionProject(t *testing.T) {
 	// TODO github action support currently disabled
 	t.SkipNow()
 
-	tempDir, err := ioutil.TempDir("", "test-import-jx-gha-")
-	assert.NoError(t, err)
+	tempDir := t.TempDir()
 
 	testData := path.Join("test_data", "import_projects")
-	_, err = os.Stat(testData)
+	_, err := os.Stat(testData)
 	assert.NoError(t, err)
 
 	name := "nodejs"

--- a/pkg/cmd/importcmd/import_golang_integration_test.go
+++ b/pkg/cmd/importcmd/import_golang_integration_test.go
@@ -3,8 +3,6 @@
 package importcmd_test
 
 import (
-	"github.com/jenkins-x/jx-helpers/v3/pkg/testhelpers"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -16,17 +14,17 @@ import (
 	"github.com/jenkins-x-plugins/jx-project/pkg/config"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/files"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/kube/naming"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/testhelpers"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestImportGoLangProject(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "test-import-jx-gha-")
-	assert.NoError(t, err)
+	tempDir := t.TempDir()
 
 	testData := path.Join("test_data", "import_projects")
-	_, err = os.Stat(testData)
+	_, err := os.Stat(testData)
 	assert.NoError(t, err)
 
 	name := "golang"

--- a/pkg/cmd/importcmd/import_integration_test.go
+++ b/pkg/cmd/importcmd/import_integration_test.go
@@ -40,11 +40,10 @@ func TestImportProjectsToJenkins(t *testing.T) {
 	// TODO jenkins import current disabled
 	t.SkipNow()
 
-	tempDir, err := ioutil.TempDir("", "test-import-projects")
-	assert.NoError(t, err)
+	tempDir := t.TempDir()
 
 	testData := path.Join("test_data", "import_projects")
-	_, err = os.Stat(testData)
+	_, err := os.Stat(testData)
 	assert.NoError(t, err)
 
 	files, err := ioutil.ReadDir(testData)
@@ -60,11 +59,10 @@ func TestImportProjectsToJenkins(t *testing.T) {
 }
 
 func TestImportProjectToJenkinsX(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "test-import-ng-projects")
-	assert.NoError(t, err)
+	tempDir := t.TempDir()
 
 	testData := path.Join("test_data", "import_projects")
-	_, err = os.Stat(testData)
+	_, err := os.Stat(testData)
 	assert.NoError(t, err)
 
 	files, err := ioutil.ReadDir(testData)

--- a/pkg/cmd/importcmd/import_jenkinsfile_integration_test.go
+++ b/pkg/cmd/importcmd/import_jenkinsfile_integration_test.go
@@ -4,7 +4,6 @@ package importcmd_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -21,11 +20,10 @@ import (
 )
 
 func TestImportJenkinsfileProject(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "test-import-jx-gha-")
-	assert.NoError(t, err)
+	tempDir := t.TempDir()
 
 	testData := path.Join("test_data", "import_projects")
-	_, err = os.Stat(testData)
+	_, err := os.Stat(testData)
 	assert.NoError(t, err)
 
 	name := "custom_jenkins"

--- a/pkg/cmd/importcmd/import_jenkinsxyml_integration_test.go
+++ b/pkg/cmd/importcmd/import_jenkinsxyml_integration_test.go
@@ -4,7 +4,6 @@ package importcmd_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -27,11 +26,10 @@ func TestImportOldProject(t *testing.T) {
 	// 'jx pipeline convert' command
 	useRealJXConvert := false
 
-	tempDir, err := ioutil.TempDir("", "test-import-jx-gha-")
-	assert.NoError(t, err)
+	tempDir := t.TempDir()
 
 	testData := path.Join("test_data", "import_projects")
-	_, err = os.Stat(testData)
+	_, err := os.Stat(testData)
 	assert.NoError(t, err)
 
 	name := "maven_custom_build_pack"

--- a/pkg/cmd/importcmd/import_placehoders_test.go
+++ b/pkg/cmd/importcmd/import_placehoders_test.go
@@ -17,11 +17,10 @@ import (
 )
 
 func TestReplacePlaceholders(t *testing.T) {
-	f, err := ioutil.TempDir("", "test-replace-placeholders")
-	assert.NoError(t, err)
+	f := t.TempDir()
 
 	testData := path.Join("test_data", "replace_placeholders")
-	_, err = os.Stat(testData)
+	_, err := os.Stat(testData)
 	assert.NoError(t, err)
 
 	files.CopyDir(testData, f, true)

--- a/pkg/cmd/importcmd/import_remote_cluster_integration_test.go
+++ b/pkg/cmd/importcmd/import_remote_cluster_integration_test.go
@@ -3,7 +3,6 @@
 package importcmd_test
 
 import (
-	"io/ioutil"
 	"path"
 	"path/filepath"
 	"strings"
@@ -20,8 +19,7 @@ import (
 )
 
 func TestImportRemoteCluster(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "test-import-jx-remote-")
-	assert.NoError(t, err)
+	tempDir := t.TempDir()
 
 	srcDir := path.Join("test_data", "remote-cluster")
 	require.DirExists(t, srcDir)
@@ -40,7 +38,7 @@ func TestImportRemoteCluster(t *testing.T) {
 	o.WaitForSourceRepositoryPullRequest = false
 	o.Destination.JenkinsX.Enabled = true
 
-	err = o.Run()
+	err := o.Run()
 	require.NoError(t, err, "Failed %s with %s", dirName, err)
 
 	assert.NoFileExists(t, filepath.Join(testDir, "Dockerfile"))

--- a/pkg/cmd/importcmd/import_tekton_catalog_integration_test.go
+++ b/pkg/cmd/importcmd/import_tekton_catalog_integration_test.go
@@ -4,7 +4,6 @@ package importcmd_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -23,11 +22,10 @@ import (
 )
 
 func TestImportTektonCatalogProject(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "test-import-jx-gha-")
-	assert.NoError(t, err)
+	tempDir := t.TempDir()
 
 	testData := path.Join("test_data", "import_projects")
-	_, err = os.Stat(testData)
+	_, err := os.Stat(testData)
 	assert.NoError(t, err)
 
 	name := "nodejs"

--- a/pkg/cmd/importcmd/import_test.go
+++ b/pkg/cmd/importcmd/import_test.go
@@ -22,13 +22,9 @@ const testUsername = "derek_zoolander"
 
 func TestCreateProwOwnersFileExistsDoNothing(t *testing.T) {
 	t.Parallel()
-	path, err := ioutil.TempDir("", "prow")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 	ownerFilePath := filepath.Join(path, "OWNERS")
-	_, err = os.Create(ownerFilePath)
+	_, err := os.Create(ownerFilePath)
 	if err != nil {
 		panic(err)
 	}
@@ -44,11 +40,7 @@ func TestCreateProwOwnersFileExistsDoNothing(t *testing.T) {
 
 func TestCreateProwOwnersFileCreateWhenDoesNotExist(t *testing.T) {
 	t.Parallel()
-	path, err := ioutil.TempDir("", "prow")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	cmd := &importcmd.ImportOptions{
 		Dir: path,
@@ -58,7 +50,7 @@ func TestCreateProwOwnersFileCreateWhenDoesNotExist(t *testing.T) {
 	}
 	cmd.ScmFactory.NoWriteGitCredentialsFile = true
 
-	err = cmd.CreateProwOwnersFile()
+	err := cmd.CreateProwOwnersFile()
 	assert.NoError(t, err, "There should be no error")
 
 	wantFile := filepath.Join(path, "OWNERS")
@@ -80,30 +72,22 @@ func TestCreateProwOwnersFileCreateWhenDoesNotExist(t *testing.T) {
 
 func TestCreateProwOwnersFileCreateWhenDoesNotExistAndNoGitUserSet(t *testing.T) {
 	t.Parallel()
-	path, err := ioutil.TempDir("", "prow")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	cmd := &importcmd.ImportOptions{
 		Dir: path,
 	}
 	cmd.ScmFactory.NoWriteGitCredentialsFile = true
 
-	err = cmd.CreateProwOwnersFile()
+	err := cmd.CreateProwOwnersFile()
 	assert.Error(t, err, "There should an error")
 }
 
 func TestCreateProwOwnersAliasesFileExistsDoNothing(t *testing.T) {
 	t.Parallel()
-	path, err := ioutil.TempDir("", "prow")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 	ownerFilePath := filepath.Join(path, "OWNERS_ALIASES")
-	_, err = os.Create(ownerFilePath)
+	_, err := os.Create(ownerFilePath)
 	if err != nil {
 		panic(err)
 	}
@@ -119,11 +103,7 @@ func TestCreateProwOwnersAliasesFileExistsDoNothing(t *testing.T) {
 
 func TestCreateProwOwnersAliasesFileCreateWhenDoesNotExist(t *testing.T) {
 	t.Parallel()
-	path, err := ioutil.TempDir("", "prow")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 	cmd := &importcmd.ImportOptions{
 		Dir: path,
 		ScmFactory: scmhelpers.Factory{
@@ -132,7 +112,7 @@ func TestCreateProwOwnersAliasesFileCreateWhenDoesNotExist(t *testing.T) {
 	}
 	cmd.ScmFactory.NoWriteGitCredentialsFile = true
 
-	err = cmd.CreateProwOwnersAliasesFile()
+	err := cmd.CreateProwOwnersAliasesFile()
 	assert.NoError(t, err, "There should be no error")
 
 	wantFile := filepath.Join(path, "OWNERS_ALIASES")
@@ -155,11 +135,7 @@ func TestCreateProwOwnersAliasesFileCreateWhenDoesNotExist(t *testing.T) {
 
 func TestCreateProwOwnersAliasesFileCreateWhenDoesNotExistAndNoGitUserSet(t *testing.T) {
 	t.Parallel()
-	path, err := ioutil.TempDir("", "prow")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	cmd := &importcmd.ImportOptions{
 		Dir: path,
@@ -169,7 +145,7 @@ func TestCreateProwOwnersAliasesFileCreateWhenDoesNotExistAndNoGitUserSet(t *tes
 	fakeScmData, _, _ := testimports.SetFakeClients(t, cmd, false)
 	fakeScmData.CurrentUser = scm.User{}
 
-	err = cmd.CreateProwOwnersAliasesFile()
+	err := cmd.CreateProwOwnersAliasesFile()
 	assert.Error(t, err, "There should an error")
 }
 

--- a/pkg/cmd/root/mlquickstart_integration_test.go
+++ b/pkg/cmd/root/mlquickstart_integration_test.go
@@ -3,7 +3,6 @@
 package root_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -13,8 +12,7 @@ import (
 )
 
 func TestCreateMLQuickstartProjects(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "test-create-mlquickstart")
-	assert.NoError(t, err)
+	testDir := t.TempDir()
 
 	appName := "mymlapp"
 
@@ -31,7 +29,7 @@ func TestCreateMLQuickstartProjects(t *testing.T) {
 	o.Repository = appName
 	o.WaitForSourceRepositoryPullRequest = false
 
-	err = o.Run()
+	err := o.Run()
 	assert.NoError(t, err)
 	if err == nil {
 		appName1 := appName + "-service"

--- a/pkg/cmd/root/quickstart_integration_test.go
+++ b/pkg/cmd/root/quickstart_integration_test.go
@@ -3,7 +3,6 @@
 package root_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -13,8 +12,7 @@ import (
 )
 
 func TestCreateQuickstartProjects(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "test-create-quickstart")
-	assert.NoError(t, err)
+	testDir := t.TempDir()
 
 	appName := "mynode"
 
@@ -31,7 +29,7 @@ func TestCreateQuickstartProjects(t *testing.T) {
 	o.Repository = appName
 	o.WaitForSourceRepositoryPullRequest = false
 
-	err = o.Run()
+	err := o.Run()
 	assert.NoError(t, err)
 	if err == nil {
 		appDir := filepath.Join(testDir, appName)
@@ -44,8 +42,7 @@ func TestCreateQuickstartProjects(t *testing.T) {
 }
 
 func TestCreateQuickstartProjectWithChart(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "test-create-quickstart-with-chart")
-	assert.NoError(t, err)
+	testDir := t.TempDir()
 
 	appName := "mynodedb"
 
@@ -62,7 +59,7 @@ func TestCreateQuickstartProjectWithChart(t *testing.T) {
 	o.Repository = appName
 	o.WaitForSourceRepositoryPullRequest = false
 
-	err = o.Run()
+	err := o.Run()
 	assert.NoError(t, err)
 	if err == nil {
 		appDir := filepath.Join(testDir, appName)

--- a/pkg/gitresolver/buildpack_test.go
+++ b/pkg/gitresolver/buildpack_test.go
@@ -3,37 +3,24 @@
 package gitresolver
 
 import (
-	"github.com/jenkins-x/jx-helpers/v3/pkg/testhelpers"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/gitclient"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/gitclient/cli"
-	"github.com/jenkins-x/jx-logging/v3/pkg/log"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/testhelpers"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildPackInitClone(t *testing.T) {
 	defaultBranch := testhelpers.GetDefaultBranch(t)
 
-	mainRepo, err := ioutil.TempDir("", uuid.New().String())
-	assert.NoError(t, err)
+	mainRepo := t.TempDir()
+	remoteRepo := t.TempDir()
 
-	remoteRepo, err := ioutil.TempDir("", uuid.New().String())
-	assert.NoError(t, err)
-
-	defer func() {
-		err := os.RemoveAll(mainRepo)
-		err2 := os.RemoveAll(remoteRepo)
-		if err != nil || err2 != nil {
-			log.Logger().Errorf("Error cleaning up tmpdirs because %v", err)
-		}
-	}()
-
-	err = os.Setenv("JX_HOME", mainRepo)
+	err := os.Setenv("JX_HOME", mainRepo)
 	assert.NoError(t, err)
 	gitDir := mainRepo + "/draft/packs"
 	err = os.MkdirAll(gitDir, 0755)


### PR DESCRIPTION
Follow up PR for https://github.com/jenkins-x-plugins/jx-gitops/pull/839#issuecomment-1079479757. This PR replaces `ioutil.TempDir` with `t.TempDir` in tests.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir