### PR TITLE
Adding Makefile target for Darwin Arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,10 @@ darwin: ## Build for OSX
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=amd64 $(GO) $(BUILD_TARGET) $(BUILDFLAGS) -o build/darwin/$(NAME) $(MAIN_SRC_FILE)
 	chmod +x build/darwin/$(NAME)
 
+darwin-arm: ## Build for OSX arm64
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=arm64 $(GO) $(BUILD_TARGET) $(BUILDFLAGS) -o build/darwin-arm/$(NAME) $(MAIN_SRC_FILE)
+	chmod +x build/darwin-arm/$(NAME)
+
 .PHONY: release
 release: clean linux test-release
 


### PR DESCRIPTION
Adding the target to build on the m1 mac.

This PR will also depend on https://github.com/jenkins-x/jx-helpers/pull/369