### PR TITLE
fix: Improved java version detection for maven projects

### DIFF
--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -29,21 +28,21 @@ import (
 const descriptionSourcePath = "docs/reference/cmd/"
 
 func generateCliYaml(opts *options) error {
-	root, _ := root.NewCmdMain()
-	disableFlagsInUseLine(root)
+	cmdMain, _ := root.NewCmdMain()
+	disableFlagsInUseLine(cmdMain)
 	source := filepath.Join(opts.source, descriptionSourcePath)
-	if err := loadLongDescription(root, source); err != nil {
+	if err := loadLongDescription(cmdMain, source); err != nil {
 		return err
 	}
 
 	switch opts.kind {
 	case "markdown":
-		return GenMarkdownTree(root, opts.target)
+		return GenMarkdownTree(cmdMain, opts.target)
 	case "man":
 		header := &GenManHeader{
 			Section: "1",
 		}
-		return GenManTree(root, header, opts.target)
+		return GenManTree(cmdMain, header, opts.target)
 	default:
 		return fmt.Errorf("invalid docs kind : %s", opts.kind)
 	}
@@ -83,7 +82,7 @@ func loadLongDescription(cmd *cobra.Command, path ...string) error {
 			continue
 		}
 
-		content, err := ioutil.ReadFile(fullpath)
+		content, err := os.ReadFile(fullpath)
 		if err != nil {
 			return err
 		}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2,7 +2,7 @@ package cache
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/jenkins-x/jx-helpers/v3/pkg/files"
@@ -17,7 +17,7 @@ const (
 	defaultCacheTimeoutHours = 24
 )
 
-// CacheLoader defines cache value population callback that should be executed if cache entry with given key is
+// Loader defines cache value population callback that should be executed if cache entry with given key is
 // not present.
 type Loader func() ([]byte, error)
 
@@ -29,9 +29,9 @@ func LoadCacheData(fileName string, loader Loader) ([]byte, error) {
 	timecheckFileName := fileName + "_last_time_check"
 	exists, _ := files.FileExists(fileName)
 	if exists {
-		// lets check if we should use cache
+		// let's check if we should use cache
 		if shouldUseCache(timecheckFileName) {
-			return ioutil.ReadFile(fileName)
+			return os.ReadFile(fileName)
 		}
 	}
 	data, err := loader()
@@ -39,7 +39,7 @@ func LoadCacheData(fileName string, loader Loader) ([]byte, error) {
 		return nil, err
 	}
 
-	err2 := ioutil.WriteFile(fileName, data, defaultFileWritePermisons)
+	err2 := os.WriteFile(fileName, data, defaultFileWritePermisons)
 	if err2 != nil {
 		log.Logger().Warnf("Failed to update cache file %s due to %s", fileName, err2)
 	}
@@ -58,7 +58,7 @@ func shouldUseCache(filePath string) bool {
 }
 
 func writeTimeToFile(path string, inputTime time.Time) error {
-	err := ioutil.WriteFile(path, []byte(inputTime.Format(timeLayout)), defaultFileWritePermisons)
+	err := os.WriteFile(path, []byte(inputTime.Format(timeLayout)), defaultFileWritePermisons)
 	if err != nil {
 		return fmt.Errorf("error writing current update time to file: %s", err)
 	}
@@ -66,7 +66,7 @@ func writeTimeToFile(path string, inputTime time.Time) error {
 }
 
 func getTimeFromFileIfExists(path string) time.Time {
-	lastUpdateCheckTime, err := ioutil.ReadFile(path)
+	lastUpdateCheckTime, err := os.ReadFile(path)
 	if err != nil {
 		return time.Time{}
 	}

--- a/pkg/cmd/importcmd/add_missing_kptfiles.go
+++ b/pkg/cmd/importcmd/add_missing_kptfiles.go
@@ -2,7 +2,6 @@ package importcmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,7 +39,7 @@ upstream:
 // createMissingLighthouseKptFiles lets create any missing Kptfile for any .lighthouse/somedir directories
 // so that after the pipeline folder has been added we can later on upgrade it from its source via kpt
 func (o *ImportOptions) createMissingLighthouseKptFiles(lighthouseDir, packName string) error {
-	fileSlice, err := ioutil.ReadDir(lighthouseDir)
+	fileSlice, err := os.ReadDir(lighthouseDir)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read dir %s", lighthouseDir)
 	}
@@ -104,7 +103,7 @@ func (o *ImportOptions) createMissingLighthouseKptFiles(lighthouseDir, packName 
 		fromDir := filepath.Join("/packs", packName, ".lighthouse", name) //nolint:gocritic
 		gitURL = strings.TrimSuffix(gitURL, ".git")
 		text := fmt.Sprintf(kptFile, name, sha, gitURL, fromDir)
-		err = ioutil.WriteFile(localKptFile, []byte(text), files.DefaultFileWritePermissions)
+		err = os.WriteFile(localKptFile, []byte(text), files.DefaultFileWritePermissions)
 		if err != nil {
 			return errors.Wrapf(err, "failed to save file %s", localKptFile)
 		}
@@ -156,7 +155,7 @@ func CheckForUsesImage(dir, triggersFile string) (bool, error) {
 }
 
 func loadJobBaseFromSourcePath(path string) (bool, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to load file %s", path)
 	}

--- a/pkg/cmd/importcmd/import_deploy_integration_test.go
+++ b/pkg/cmd/importcmd/import_deploy_integration_test.go
@@ -1,10 +1,11 @@
+//go:build integration
 // +build integration
 
 package importcmd_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"testing"
@@ -23,7 +24,6 @@ import (
 )
 
 func TestImportProjectNextGenPipelineWithDeploy(t *testing.T) {
-	// TODO
 	t.SkipNow()
 
 	t.Parallel()
@@ -176,8 +176,8 @@ func assertImportHasDeploy(t *testing.T, o *importcmd.ImportOptions, testDir str
 		t.Logf("completed test in dir %s", testDir)
 
 		// lets validate the resulting values.yaml
-		//yamlData, err := ioutil.ReadFile(valuesFile)
-		_, err := ioutil.ReadFile(valuesFile)
+		//yamlData, err := os.ReadFile(valuesFile)
+		_, err := os.ReadFile(valuesFile)
 		assert.NoError(t, err, "Failed to load file %s", valuesFile)
 
 		/* TODO

--- a/pkg/cmd/importcmd/import_integration_test.go
+++ b/pkg/cmd/importcmd/import_integration_test.go
@@ -1,9 +1,9 @@
+//go:build integration
 // +build integration
 
 package importcmd_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -46,7 +46,7 @@ func TestImportProjectsToJenkins(t *testing.T) {
 	_, err := os.Stat(testData)
 	assert.NoError(t, err)
 
-	files, err := ioutil.ReadDir(testData)
+	files, err := os.ReadDir(testData)
 	assert.NoError(t, err)
 
 	for _, f := range files {
@@ -65,7 +65,7 @@ func TestImportProjectToJenkinsX(t *testing.T) {
 	_, err := os.Stat(testData)
 	assert.NoError(t, err)
 
-	files, err := ioutil.ReadDir(testData)
+	files, err := os.ReadDir(testData)
 	assert.NoError(t, err)
 
 	for _, f := range files {
@@ -131,7 +131,7 @@ func assertImport(t *testing.T, testDir string, testcase string, importToJenkins
 		exists, err := files.FileExists(jenkinsfile)
 		require.NoError(t, err, "could not check for file %s", jenkinsfile)
 		if !exists {
-			err = ioutil.WriteFile(jenkinsfile, []byte("node {}"), files.DefaultFileWritePermissions)
+			err = os.WriteFile(jenkinsfile, []byte("node {}"), files.DefaultFileWritePermissions)
 			require.NoError(t, err, "failed to write dummy Jenkinsfile to %s", jenkinsfile)
 		}
 	}
@@ -220,7 +220,7 @@ func assertImport(t *testing.T, testDir string, testcase string, importToJenkins
 
 func assertProbePathEquals(t *testing.T, fileName string, expectedProbe string) {
 	if assert.FileExists(t, fileName) {
-		data, err := ioutil.ReadFile(fileName)
+		data, err := os.ReadFile(fileName)
 		assert.NoError(t, err, "Failed to read file %s", fileName)
 		if err == nil {
 			text := string(data)

--- a/pkg/cmd/importcmd/import_placehoders_test.go
+++ b/pkg/cmd/importcmd/import_placehoders_test.go
@@ -1,10 +1,10 @@
+//go:build unit
 // +build unit
 
 package importcmd_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -69,7 +69,7 @@ func TestReplacePlaceholders(t *testing.T) {
 // loads a file
 func LoadBytes(dir, name string) ([]byte, error) {
 	path := filepath.Join(dir, name) // relative path
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("error loading file %s in directory %s, %v", name, dir, err)
 	}

--- a/pkg/cmd/importcmd/import_test.go
+++ b/pkg/cmd/importcmd/import_test.go
@@ -1,9 +1,9 @@
+//go:build unit
 // +build unit
 
 package importcmd_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -62,7 +62,7 @@ func TestCreateProwOwnersFileCreateWhenDoesNotExist(t *testing.T) {
 		Approvers: []string{testUsername},
 		Reviewers: []string{testUsername},
 	}
-	data, err := ioutil.ReadFile(wantFile)
+	data, err := os.ReadFile(wantFile)
 	assert.NoError(t, err, "It should read the OWNERS file without error")
 	owners := prow.Owners{}
 	err = yaml.Unmarshal(data, &owners)
@@ -125,7 +125,7 @@ func TestCreateProwOwnersAliasesFileCreateWhenDoesNotExist(t *testing.T) {
 		BestApprovers: []string{testUsername},
 		BestReviewers: []string{testUsername},
 	}
-	data, err := ioutil.ReadFile(wantFile)
+	data, err := os.ReadFile(wantFile)
 	assert.NoError(t, err, "It should read the OWNERS_ALIASES file without error")
 	ownersAliases := prow.OwnersAliases{}
 	err = yaml.Unmarshal(data, &ownersAliases)

--- a/pkg/cmd/importcmd/pom_flavour_test.go
+++ b/pkg/cmd/importcmd/pom_flavour_test.go
@@ -1,10 +1,11 @@
+//go:build unit
 // +build unit
 
 package importcmd_test
 
 import (
-	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/jenkins-x-plugins/jx-project/pkg/cmd/importcmd"
@@ -14,41 +15,55 @@ import (
 func TestMavenIsDefault(t *testing.T) {
 	t.Parallel()
 
-	file, err := ioutil.TempFile("", "jx_test")
+	genericMaven(t, "", importcmd.MAVEN, "")
+}
+
+func TestMavenJava17Detection(t *testing.T) {
+	t.Parallel()
+
+	pack := "maven-java17"
+	packDir, err := os.MkdirTemp("", "jx_test")
 	assert.Nil(t, err)
-	err = ioutil.WriteFile(file.Name(), []byte(""), 0600)
+	os.Mkdir(filepath.Join(packDir, pack), 0700)
 	assert.Nil(t, err)
-	flavour, err := importcmd.PomFlavour(file.Name())
-	assert.Nil(t, err)
-	assert.Equal(t, importcmd.MAVEN, flavour)
-	err = os.Remove(file.Name())
+	genericMaven(t, packDir, pack, "<maven.compiler.release>17</maven.compiler.release>")
+	err = os.RemoveAll(packDir)
 	assert.Nil(t, err)
 }
 
 func TestMavenJava11Detection(t *testing.T) {
 	t.Parallel()
 
-	file, err := ioutil.TempFile("", "jx_test")
+	pack := "maven-java11"
+	packDir, err := os.MkdirTemp("", "jx_test")
 	assert.Nil(t, err)
-	err = ioutil.WriteFile(file.Name(), []byte("<java.version>11</java.version>"), 0600)
+	os.Mkdir(filepath.Join(packDir, pack), 0700)
 	assert.Nil(t, err)
-	flavour, err := importcmd.PomFlavour(file.Name())
+	genericMaven(t, packDir, pack, "<java.version>11</java.version>")
+	err = os.RemoveAll(packDir)
 	assert.Nil(t, err)
-	assert.Equal(t, importcmd.MAVENJAVA11, flavour)
-	err = os.Remove(file.Name())
-	assert.Nil(t, err)
+}
+
+func TestMavenDefaultJavaDetection(t *testing.T) {
+	t.Parallel()
+
+	genericMaven(t, ".", importcmd.MAVEN, "<java.version>11</java.version>")
 }
 
 func TestLibertyDetection(t *testing.T) {
 	t.Parallel()
 
-	file, err := ioutil.TempFile("", "jx_test")
+	genericMaven(t, "", importcmd.DROPWIZARD, "<groupId>io.dropwizard")
+}
+
+func genericMaven(t *testing.T, packsDir, expectedFlavour, testFileContent string) {
+	file, err := os.CreateTemp("", "jx_test")
 	assert.Nil(t, err)
-	err = ioutil.WriteFile(file.Name(), []byte("<groupId>io.dropwizard"), 0600)
+	err = os.WriteFile(file.Name(), []byte(testFileContent), 0600)
 	assert.Nil(t, err)
-	flavour, err := importcmd.PomFlavour(file.Name())
+	flavour, err := importcmd.PomFlavour(packsDir, file.Name())
 	assert.Nil(t, err)
-	assert.Equal(t, importcmd.DROPWIZARD, flavour)
+	assert.Equal(t, expectedFlavour, flavour)
 	err = os.Remove(file.Name())
 	assert.Nil(t, err)
 }

--- a/pkg/cmd/root/mlquickstart.go
+++ b/pkg/cmd/root/mlquickstart.go
@@ -3,7 +3,7 @@ package root
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -260,7 +260,7 @@ func (o *CreateMLQuickstartOptions) getMLProjectSet(q *quickstarts.Quickstart) (
 		return nil, err
 	}
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/root/quickstart.go
+++ b/pkg/cmd/root/quickstart.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -278,7 +279,7 @@ func (o *CreateQuickstartOptions) createQuickstart(f *quickstarts.QuickstartForm
 		return answer, err
 	}
 
-	// lets not pass in a token if we are not using a similar service (e.g. github.com or mygitserver.com)
+	// let's not pass in a token if we are not using a similar service (e.g. github.com or mygitserver.com)
 	sameDomain, err := SameRootDomain(o.ScmFactory.GitServerURL, u)
 	if err != nil {
 		return answer, errors.Wrapf(err, "failed to compare domains")
@@ -309,13 +310,13 @@ func (o *CreateQuickstartOptions) createQuickstart(f *quickstarts.QuickstartForm
 		return answer, err
 	}
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return answer, err
 	}
 
 	zipFile := filepath.Join(dir, "source.zip")
-	err = ioutil.WriteFile(zipFile, body, files.DefaultFileWritePermissions)
+	err = os.WriteFile(zipFile, body, files.DefaultFileWritePermissions)
 	if err != nil {
 		return answer, fmt.Errorf("failed to download file %s due to %s", zipFile, err)
 	}
@@ -344,11 +345,11 @@ func (o *CreateQuickstartOptions) createQuickstart(f *quickstarts.QuickstartForm
 }
 
 func findFirstDirectory(dir string) (string, error) {
-	files, err := ioutil.ReadDir(dir)
+	fileList, err := os.ReadDir(dir)
 	if err != nil {
 		return dir, err
 	}
-	for _, f := range files {
+	for _, f := range fileList {
 		if f.IsDir() {
 			return filepath.Join(dir, f.Name()), nil
 		}
@@ -379,7 +380,7 @@ func isMLProjectSet(q *quickstarts.Quickstart, username, token string) bool {
 		return false
 	}
 	defer res.Body.Close()
-	bodybytes, err := ioutil.ReadAll(res.Body)
+	bodybytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Logger().Warnf("Problem parsing response body from %s: %s ", u, err)
 		return false

--- a/pkg/config/project_config.go
+++ b/pkg/config/project_config.go
@@ -2,6 +2,9 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/jenkins-x-plugins/jx-project/pkg/jenkinsfile"
@@ -10,10 +13,6 @@ import (
 	"github.com/jenkins-x/jx-helpers/v3/pkg/yamls/validate"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
-
-	"io/ioutil"
-	"path/filepath"
-	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -90,7 +89,7 @@ func LoadProjectConfigFile(fileName string) (*ProjectConfig, error) {
 	if err != nil || !exists {
 		return &config, err
 	}
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		return &config, fmt.Errorf("Failed to load file %s due to %s", fileName, err)
 	}
@@ -120,7 +119,7 @@ func (c *ProjectConfig) SaveConfig(fileName string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(fileName, data, files.DefaultFileWritePermissions)
+	err = os.WriteFile(fileName, data, files.DefaultFileWritePermissions)
 	if err != nil {
 		return errors.Wrapf(err, "failed to save file %s", fileName)
 	}

--- a/pkg/draft/draft.go
+++ b/pkg/draft/draft.go
@@ -3,7 +3,7 @@ package draft
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -34,13 +34,13 @@ func DoPackDetection(home draftpath.Home, out io.Writer, dir string) (string, er
 		fmt.Fprintf(out, "--> Draft detected %s (%f%%)\n", detectedLang.Language, detectedLang.Percent)
 		for _, repository := range repo.FindRepositories(home.Packs()) {
 			packDir := path.Join(repository.Dir, repo.PackDirName)
-			packs, err := ioutil.ReadDir(packDir)
+			packs, err := os.ReadDir(packDir)
 			if err != nil {
 				return "", fmt.Errorf("there was an error reading %s: %v", packDir, err)
 			}
 			for _, file := range packs {
 				if file.IsDir() {
-					if strings.Compare(strings.ToLower(detectedLang.Language), strings.ToLower(file.Name())) == 0 {
+					if strings.EqualFold(detectedLang.Language, file.Name()) {
 						packPath := filepath.Join(packDir, file.Name())
 						return packPath, nil
 					}
@@ -65,13 +65,13 @@ func DoPackDetectionForBuildPack(out io.Writer, dir, packDir string) (string, er
 	for _, lang := range langs {
 		detectedLang := linguist.Alias(lang)
 		fmt.Fprintf(out, "--> Draft detected %s (%f%%)\n", detectedLang.Language, detectedLang.Percent)
-		packs, err := ioutil.ReadDir(packDir)
+		packs, err := os.ReadDir(packDir)
 		if err != nil {
 			return "", fmt.Errorf("there was an error reading %s: %v", packDir, err)
 		}
 		for _, file := range packs {
 			if file.IsDir() {
-				if strings.Compare(strings.ToLower(detectedLang.Language), strings.ToLower(file.Name())) == 0 {
+				if strings.EqualFold(detectedLang.Language, file.Name()) {
 					packPath := filepath.Join(packDir, file.Name())
 					return packPath, nil
 				}

--- a/pkg/gitresolver/buildpack_test.go
+++ b/pkg/gitresolver/buildpack_test.go
@@ -1,9 +1,9 @@
+//go:build unit
 // +build unit
 
 package gitresolver
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +37,7 @@ func TestBuildPackInitClone(t *testing.T) {
 	initialReadme := "Cheesy!"
 
 	readmePath := filepath.Join(remoteRepo, readme)
-	err = ioutil.WriteFile(readmePath, []byte(initialReadme), 0600)
+	err = os.WriteFile(readmePath, []byte(initialReadme), 0600)
 	assert.NoError(t, err)
 	_, err = gitclient.AddAndCommitFiles(gitter, remoteRepo, "chore: Initial Commit")
 	assert.NoError(t, err, "failed to add and commit files")
@@ -65,7 +65,6 @@ func TestBuildPackInitClone(t *testing.T) {
 	output, err := gitter.Command(gitDir, "status", "-sb")
 	assert.NoError(t, err)
 	// Check the current branch is tracking the origin/master one
-	// TODO
 	assert.Equal(t, "## master", output)
 	//assert.Equal(t, "## master...origin/master", output)
 }

--- a/pkg/jenkinsfile/pipeline.go
+++ b/pkg/jenkinsfile/pipeline.go
@@ -2,7 +2,6 @@ package jenkinsfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -489,7 +488,7 @@ func LoadPipelineConfigAndMaybeValidate(fileName string, resolver ImportFileReso
 	if err != nil || !exists {
 		return &config, err
 	}
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		return &config, errors.Wrapf(err, "Failed to load file %s", fileName)
 	}
@@ -594,7 +593,7 @@ func (c *PipelineConfig) SaveConfig(fileName string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(fileName, data, files.DefaultFileWritePermissions)
+	return os.WriteFile(fileName, data, files.DefaultFileWritePermissions)
 }
 
 // ExtendPipeline inherits this pipeline from the given base pipeline
@@ -768,7 +767,7 @@ func (a *CreateJenkinsfileArguments) GenerateJenkinsfile(resolver ImportFileReso
 
 	templateFile := a.TemplateFile
 
-	data, err := ioutil.ReadFile(templateFile)
+	data, err := os.ReadFile(templateFile)
 	if err != nil {
 		return errors.Wrapf(err, "failed to load template %s", templateFile)
 	}

--- a/pkg/maven/cli.go
+++ b/pkg/maven/cli.go
@@ -2,7 +2,6 @@ package maven
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -83,7 +82,7 @@ func InstallMavenIfRequired(runner cmdrunner.CommandRunner) error {
 
 	// lets find a directory inside the unzipped folder
 	log.Logger().Info("\nReadDir")
-	files, err := ioutil.ReadDir(mvnTmpDir)
+	files, err := os.ReadDir(mvnTmpDir)
 	if err != nil {
 		err = m.Unlock()
 		if err != nil {

--- a/pkg/spring/model.go
+++ b/pkg/spring/model.go
@@ -3,7 +3,7 @@ package spring
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -108,7 +108,7 @@ type errorResponse struct {
 func LoadSpringBoot(cacheDir string) (*BootModel, error) {
 	loader := func() ([]byte, error) {
 		client := http.Client{}
-		req, err := http.NewRequest(http.MethodGet, startSpringURL, nil)
+		req, err := http.NewRequest(http.MethodGet, startSpringURL, http.NoBody)
 		if err != nil {
 			return nil, err
 		}
@@ -120,7 +120,7 @@ func LoadSpringBoot(cacheDir string) (*BootModel, error) {
 			return nil, err
 		}
 		defer res.Body.Close()
-		return ioutil.ReadAll(res.Body)
+		return io.ReadAll(res.Body)
 	}
 
 	cacheFileName := ""
@@ -354,7 +354,7 @@ func (data *BootForm) CreateProject(workDir string) (string, error) {
 	}
 	defer res.Body.Close()
 	if res.StatusCode == 400 {
-		errorBody, err := ioutil.ReadAll(res.Body)
+		errorBody, err := io.ReadAll(res.Body)
 		if err != nil {
 			return answer, err
 		}
@@ -369,14 +369,14 @@ func (data *BootForm) CreateProject(workDir string) (string, error) {
 		return answer, errors.New("unable to create spring quickstart")
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return answer, err
 	}
 
 	dir := filepath.Join(workDir, dirName)
 	zipFile := dir + ".zip"
-	err = ioutil.WriteFile(zipFile, body, files.DefaultFileWritePermissions)
+	err = os.WriteFile(zipFile, body, files.DefaultFileWritePermissions)
 	if err != nil {
 		return answer, fmt.Errorf("failed to download file %s due to %s", zipFile, err)
 	}


### PR DESCRIPTION
Supports a couple more ways to specify java version in pom.xml.
Supports more java versions without the need to specify each.

Without this fix a quickstart using maven can't use other java version than 1.8 and 11, since the correct pack won't be chosen.

This is in [pkg/cmd/importcmd/pom_flavour.go](https://github.com/jenkins-x-plugins/jx-project/pull/506/files#diff-40f424264061b9cee08382ca60a7eaa46f62e8b60c8f1a1c5d9a95f386979161)

The rest are linting and inspection fixes