### PR TITLE
Skip importing app chart from pack if it already exists

### DIFF
--- a/pkg/cmd/importcmd/buildpacks.go
+++ b/pkg/cmd/importcmd/buildpacks.go
@@ -289,7 +289,7 @@ func (o *ImportOptions) InvokeDraftPack(i *InvokeDraftPack) (string, error) {
 		return pack, err
 	}
 
-	err = copyBuildPack(dir, lpack, o.PackFilter)
+	err = o.copyBuildPack(dir, lpack)
 	if err != nil {
 		log.Logger().Warnf("Failed to apply the build pack in %s due to %s", dir, err)
 	}
@@ -368,7 +368,7 @@ func (o *ImportOptions) DiscoverBuildPack(dir string, projectConfig *config.Proj
 
 // Refactor: taken from jx so we can also bring in the draft pack and not fail when copying buildpacks without a charts dir
 // CopyBuildPack copies the build pack from the source dir to the destination dir
-func copyBuildPack(dest, src string, filter func(*Pack)) error {
+func (o *ImportOptions) copyBuildPack(dest, src string) error {
 	// first do some validation that we are copying from a valid pack directory
 	p, err := FromDir(src)
 	if err != nil {
@@ -376,8 +376,7 @@ func copyBuildPack(dest, src string, filter func(*Pack)) error {
 	}
 
 	chartsDir := filepath.Join(dest, "charts")
-	_, appName := filepath.Split(dest)
-	newDir := filepath.Join(chartsDir, appName)
+	newDir := filepath.Join(chartsDir, o.AppName)
 	exists, err := files.DirExists(newDir)
 	if err != nil {
 		return errors.Wrapf(err, "failed to check if chart directory exists %s", newDir)
@@ -426,8 +425,8 @@ func copyBuildPack(dest, src string, filter func(*Pack)) error {
 		delete(p.Files, file)
 	}
 
-	if filter != nil {
-		filter(p)
+	if o.PackFilter != nil {
+		o.PackFilter(p)
 	}
 
 	_, packName := filepath.Split(src)

--- a/pkg/cmd/importcmd/import_integration_test.go
+++ b/pkg/cmd/importcmd/import_integration_test.go
@@ -182,6 +182,16 @@ func assertImport(t *testing.T, testDir string, testcase string, importToJenkins
 					testhelpers.AssertFileDoesNotContain(t, jfname, "helm")
 				}
 			} else {
+				chartEntries, err := os.ReadDir(filepath.Join(testDir, "charts"))
+				assert.NoError(t, err, "can't read charts directory")
+				t.Logf("Content of chart %s:", filepath.Join(testDir, "charts"))
+				for _, d := range chartEntries {
+					t.Log(d.Name())
+
+					if d.IsDir() {
+						assert.Equal(t, dirName, d.Name(), "Expect only application chart in charts directory")
+					}
+				}
 				assert.FileExists(t, filepath.Join(testDir, "charts", dirName, "Chart.yaml"))
 			}
 		} else {

--- a/pkg/cmd/importcmd/test_data/import_projects/maven_existing_project/charts/maven-existing-project/Chart.yaml
+++ b/pkg/cmd/importcmd/test_data/import_projects/maven_existing_project/charts/maven-existing-project/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+appVersion: "7.0.0.RC1"
+description: A Helm Chart
+name: REPLACE_ME_APP_NAME
+version: 0.0.1-SNAPSHOT
+dependencies:
+- name: mychart
+  version: 1.2.3
+- name: anotherchart
+  version: 4.5.6

--- a/pkg/cmd/importcmd/test_data/import_projects/maven_existing_project/pom.xml
+++ b/pkg/cmd/importcmd/test_data/import_projects/maven_existing_project/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>demo2</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>demo</name>
+  <description>Demo project for Spring Boot</description>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.0.1.RELEASE</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+
+</project>

--- a/pkg/cmd/importcmd/test_data/import_projects/maven_quickstart/charts/Chart.yaml
+++ b/pkg/cmd/importcmd/test_data/import_projects/maven_quickstart/charts/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+appVersion: "7.0.0.RC1"
+description: A Helm Chart
+name: REPLACE_ME_APP_NAME
+version: 0.0.1-SNAPSHOT
+dependencies:
+- name: mychart
+  version: 1.2.3
+- name: anotherchart
+  version: 4.5.6

--- a/pkg/cmd/importcmd/test_data/import_projects/maven_quickstart/pom.xml
+++ b/pkg/cmd/importcmd/test_data/import_projects/maven_quickstart/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>demo2</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>demo</name>
+  <description>Demo project for Spring Boot</description>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.0.1.RELEASE</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+
+</project>


### PR DESCRIPTION
A typical case is if you migrate a repo from one Jenkins X cluster to another.

Without this fix you eventually get an error when jx-project tries to rename the imported chart to the app name. Also you en up with a superfluous chart from the pack.